### PR TITLE
update run_mlperf.sh for aws compatibility (dlrm 99.9)

### DIFF
--- a/closed/Intel/code/dlrm-99.9/pytorch-cpu/run_mlperf.sh
+++ b/closed/Intel/code/dlrm-99.9/pytorch-cpu/run_mlperf.sh
@@ -37,7 +37,7 @@ fi
 
 if [ ${mode} = "server" ]; then
     scenario="server"
-    source /workspace/setup_env_server.sh
+    source /workspace/setup_env_server_ICX.sh
 fi
 
 if [ ${run_type} = "perf" ];then


### PR DESCRIPTION
Fixed source in run_mlperf.sh to point to setup_env_server_ICX.sh file instead of the non-ICX file. This is for AWS compatibility. 