### PR TITLE
Modify the settings to support ICX on AWS

### DIFF
--- a/closed/Intel/code/README.md
+++ b/closed/Intel/code/README.md
@@ -46,7 +46,7 @@ cd resnet50/pytorch-cpu/
 cd dlrm-99.9/pytorch-cpu/
 ```
 ```
-../../run_docker.sh 038cf950d509  /workspace/RUN.sh  /opt/workdir/code/dlrm-99.9/pytorch-cpu aws_dlrm
+../../run_docker.sh 038cf950d509  /workspace/run_offline.sh  /opt/workdir/code/dlrm-99.9/pytorch-cpu aws_dlrm
 ```
 
 ### Retinanet

--- a/closed/Intel/code/README.md
+++ b/closed/Intel/code/README.md
@@ -47,6 +47,7 @@ cd dlrm-99.9/pytorch-cpu/
 ```
 ```
 ../../run_docker.sh 038cf950d509  /workspace/run_offline.sh  /opt/workdir/code/dlrm-99.9/pytorch-cpu aws_dlrm
+# Please change 'run_offline.sh' to 'run_offline_accuracy.sh', 'run_server.sh' or 'run_server_accuracy.sh' accordingly, based on your desired benchmark type and the mode.
 ```
 
 ### Retinanet

--- a/closed/Intel/code/dlrm-99.9/pytorch-cpu/RUN.sh
+++ b/closed/Intel/code/dlrm-99.9/pytorch-cpu/RUN.sh
@@ -1,1 +1,0 @@
-/workspace/run_mlperf.sh --mode=offline --type=perf --dtype=int8

--- a/closed/Intel/code/dlrm-99.9/pytorch-cpu/run_offline.sh
+++ b/closed/Intel/code/dlrm-99.9/pytorch-cpu/run_offline.sh
@@ -1,0 +1,1 @@
+/workspace/run_mlperf.sh --mode=offline --type=perf --dtype=int8

--- a/closed/Intel/code/dlrm-99.9/pytorch-cpu/run_offline_accuracy.sh
+++ b/closed/Intel/code/dlrm-99.9/pytorch-cpu/run_offline_accuracy.sh
@@ -1,0 +1,1 @@
+/workspace/run_mlperf.sh --mode=offline --type=acc --dtype=int8

--- a/closed/Intel/code/dlrm-99.9/pytorch-cpu/run_server.sh
+++ b/closed/Intel/code/dlrm-99.9/pytorch-cpu/run_server.sh
@@ -1,0 +1,1 @@
+/workspace/run_mlperf.sh --mode=server --type=perf --dtype=int8

--- a/closed/Intel/code/dlrm-99.9/pytorch-cpu/run_server_accuracy.sh
+++ b/closed/Intel/code/dlrm-99.9/pytorch-cpu/run_server_accuracy.sh
@@ -1,0 +1,1 @@
+/workspace/run_mlperf.sh --mode=server --type=acc --dtype=int8

--- a/closed/Intel/code/dlrm-99.9/pytorch-cpu/setup_env_server_ICX.sh
+++ b/closed/Intel/code/dlrm-99.9/pytorch-cpu/setup_env_server_ICX.sh
@@ -10,4 +10,3 @@ export CPUS_PER_PROCESS=$cpu_per_socket  # which determine how much processes wi
 export CPUS_PER_INSTANCE=2  # instance-per-process number=CPUS_PER_PROCESS/CPUS_PER_INSTANCE
                              # total-instance = instance-per-process * process-per-socket
 export BATCH_SIZE=8000
-export DNNL_MAX_CPU_ISA=AVX512_CORE_AMX

--- a/closed/Intel/code/dlrm-99.9/pytorch-cpu/setup_env_server_ICX.sh
+++ b/closed/Intel/code/dlrm-99.9/pytorch-cpu/setup_env_server_ICX.sh
@@ -7,6 +7,6 @@ export NUM_SOCKETS=$number_sockets        # i.e. 8
 export CPUS_PER_SOCKET=$cpu_per_socket   # i.e. 28
 export CPUS_PER_PROCESS=$cpu_per_socket  # which determine how much processes will be used
                                          # process-per-socket = CPUS_PER_SOCKET/CPUS_PER_PROCESS
-export CPUS_PER_INSTANCE=2  # instance-per-process number=CPUS_PER_PROCESS/CPUS_PER_INSTANCE
+export CPUS_PER_INSTANCE=8  # instance-per-process number=CPUS_PER_PROCESS/CPUS_PER_INSTANCE
                              # total-instance = instance-per-process * process-per-socket
 export BATCH_SIZE=8000

--- a/closed/Intel/code/dlrm-99.9/pytorch-cpu/user.conf.ICX40C_2S
+++ b/closed/Intel/code/dlrm-99.9/pytorch-cpu/user.conf.ICX40C_2S
@@ -1,0 +1,2 @@
+dlrm.Server.target_qps = 14000.0
+dlrm.Offline.target_qps = 100430.0

--- a/closed/Intel/code/run_docker.sh
+++ b/closed/Intel/code/run_docker.sh
@@ -35,5 +35,6 @@ docker run -a stdout  $DOCKER_RUN_ENVS  \
     --privileged --init -it \
     --net host \
     --name "$name" $gpu_arg \
+    --ipc host \
     "$image_id" \
     "$commands"


### PR DESCRIPTION
* Add ipc flag to increase the shared memory in Docker to solve dataloader issue
* Add support to run in offline/server mode and perf/acc type
* Modify the dlrm running script in Readme to align
* Modify the cores per instance from 2 to 8 to make the perf results on ICX_2S in server mode valid
* Add user.conf for ICX32C_2S config to make the perf results on ICX_2S in server mode valid